### PR TITLE
WIP: Add disallow overwrite option

### DIFF
--- a/lib/middleman-webp/converter.rb
+++ b/lib/middleman-webp/converter.rb
@@ -33,10 +33,12 @@ module Middleman
         paths.each do |p|
           begin
             dst = destination_path(p)
+            next dont_convert(dst) if @options.disallow_overwrite && File.exist?(dst)
             exec_convert_tool(p, dst)
             yield File.new(p), File.new(dst.to_s)
           rescue StandardError => e
-            @builder.trigger :error, "Converting #{p} failed", "#{e.to_s}\nBacktrace:\n\t#{e.backtrace.join("\n\t")}"
+            @builder.trigger :error, "Converting #{p} failed", "#{e.to_s}\n"\
+              "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
           end
         end
       end
@@ -56,6 +58,10 @@ module Middleman
       def reject_file(file)
         @builder.trigger :deleted, "#{file.path} skipped"
         File.unlink(file)
+      end
+
+      def dont_convert(file)
+        @builder.trigger :identical, "#{file} already exists, skipped"
       end
 
       def print_summary

--- a/lib/middleman-webp/extension.rb
+++ b/lib/middleman-webp/extension.rb
@@ -22,6 +22,8 @@ module Middleman
            'their source')
     option(:run_before_build, false, 'Run before build and save .webp files in'\
            ' source dir')
+    option(:disallow_overwrite, false, 'Prevent existing .webp files with' \
+           ' matching filenames from being overwritten')
 
     def initialize(app, options_hash = {}, &block)
       super

--- a/lib/middleman-webp/options.rb
+++ b/lib/middleman-webp/options.rb
@@ -4,7 +4,7 @@ module Middleman
   module WebP
     class Options
       attr_reader :ignore, :verbose, :append_extension, :allow_skip,
-        :run_before_build
+        :run_before_build, :disallow_overwrite
 
       def initialize(options = {})
         @ignore = options[:ignore] || []
@@ -23,6 +23,7 @@ module Middleman
         @append_extension = options[:append_extension] || false
         @allow_skip = !(false == options[:allow_skip])
         @run_before_build = options[:run_before_build] || false
+        @disallow_overwrite = !(false == options[:disallow_overwrite])
       end
 
       # Internal: Generate command line args for cwebp or gif2webp command


### PR DESCRIPTION
Adds a disallow overwrite option so that if conversion is run before the build the extension will skip conversion if a file already exists at the destination path.  This lets us commit the webp files to our source directory but not thrash them on subsequent builds.

WIP for tests.